### PR TITLE
减少ModuleClassLoader加载Class时锁的粒度

### DIFF
--- a/jarslink-api/src/main/java/com/alipay/jarslink/api/impl/ModuleClassLoader.java
+++ b/jarslink-api/src/main/java/com/alipay/jarslink/api/impl/ModuleClassLoader.java
@@ -35,24 +35,29 @@ import static com.google.common.collect.Iterables.any;
  * 模块的ClassLoader，继承自URLClassLoader，同时可以强制指定一些包下的class，由本ClassLoader自己加载，不通过父ClassLoader加载，突破双亲委派机制。
  *
  * @author tengfei.fangtf
- *
  * @version $Id: ModuleClassLoader.java, v 0.1 Mar 20, 2017 4:04:32 PM tengfei.fangtf Exp $
  */
 public class ModuleClassLoader extends URLClassLoader {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ModuleClassLoader.class);
 
-    /** java的包必须排除，避免安全隐患 */
-    public static final String[] DEFAULT_EXCLUDED_PACKAGES = new String[] {"java.", "javax.", "sun.", "oracle."};
+    /**
+     * java的包必须排除，避免安全隐患
+     */
+    public static final String[] DEFAULT_EXCLUDED_PACKAGES = new String[]{"java.", "javax.", "sun.", "oracle."};
 
-    /** 需要排除的包 */
-    private final Set<String> excludedPackages = new HashSet<String>();
+    /**
+     * 需要排除的包
+     */
+    private final Set<String> excludedPackages = new HashSet<>();
 
-    /** 需要子加载器优先加载的包 */
+    /**
+     * 需要子加载器优先加载的包
+     */
     private final List<String> overridePackages;
 
     public ModuleClassLoader(List<URL> urls, ClassLoader parent, List<String> overridePackages) {
-        super(urls.toArray(new URL[] {}), parent);
+        super(urls.toArray(new URL[]{}), parent);
         this.overridePackages = overridePackages;
         this.excludedPackages.addAll(Sets.newHashSet(DEFAULT_EXCLUDED_PACKAGES));
     }
@@ -65,7 +70,7 @@ public class ModuleClassLoader extends URLClassLoader {
     @Override
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
         Class<?> result = null;
-        synchronized (ModuleClassLoader.class) {
+        synchronized (getClassLoadingLock(name)) {
             if (isEligibleForOverriding(name)) {
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info("Load class for overriding: {}", name);
@@ -104,6 +109,7 @@ public class ModuleClassLoader extends URLClassLoader {
 
     /**
      * 判断该名字是否是需要覆盖的 class
+     *
      * @param name
      * @return
      */


### PR DESCRIPTION
原来ModuleClassLoader的实现是在loadClasss时锁住整个类，现在改为为锁住每个classname。
同时代码进行了格式化。